### PR TITLE
Problem: PR review overhead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @calvinaco @devashishdxt @JayT106 @leejw51crypto @thomas-nguy @tomtau @yihuang
+*       @crypto-org-chain/cronos-dev


### PR DESCRIPTION
Solution: created a team in https://github.com/orgs/crypto-org-chain/teams/cronos-dev/
and set up auto-assignment: https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-assignment-for-your-team
for 2 people in round-robin
