### PR TITLE
Problem: codeql-go is deprecated

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,7 +50,7 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: "go"
-          queries: +security-and-quality,github/codeql-go/ql/src/experimental/InconsistentCode/DeferInLoop.ql@main,github/codeql-go/ql/src/experimental/Unsafe/WrongUsageOfUnsafe.ql@main,github/codeql-go/ql/src/experimental/CWE-369/DivideByZero.ql@main
+          queries: +security-and-quality,github/codeql/go/ql/src/experimental/InconsistentCode/DeferInLoop.ql@main,github/codeql/go/ql/src/experimental/Unsafe/WrongUsageOfUnsafe.ql@main,github/codeql/go/ql/src/experimental/CWE-369/DivideByZero.ql@main
           packs: +crypto-com/cosmos-sdk-codeql
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.


### PR DESCRIPTION
Solution: updated the query paths to the new repository
